### PR TITLE
Added header search paths so the project would build. 

### DIFF
--- a/rnutils.xcodeproj/project.pbxproj
+++ b/rnutils.xcodeproj/project.pbxproj
@@ -212,6 +212,10 @@
 		8708FD791BD8D5A4001CD5EC /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SRCROOT)/../react-native/React/**",
+				);
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -221,6 +225,10 @@
 		8708FD7A1BD8D5A4001CD5EC /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SRCROOT)/../react-native/React/**",
+				);
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;


### PR DESCRIPTION
Added header search paths so the project would build.  Without them, you get build errors.
